### PR TITLE
fixes #89

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,14 +92,14 @@ gem 'globalize-accessors'
 gem 'commontator'
 gem 'acts_as_votable'
 
-group :development, :test do
+group :development, :docker_development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'factory_bot_rails'
 end
 
-group :development do
+group :development, :docker_development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'


### PR DESCRIPTION
This adds the missing gems to the main branch. We should always have a main branch that builds.